### PR TITLE
Update autocomplete.js

### DIFF
--- a/lib/ace/autocomplete.js
+++ b/lib/ace/autocomplete.js
@@ -143,7 +143,7 @@ var Autocomplete = function() {
         // on IE preventDefault doesn't stop scrollbar from being focussed
         var el = document.activeElement;
         var text = this.editor.textInput.getElement()
-        if (el != text && el.parentNode != this.popup.container
+        if (el != text && this.popup && el.parentNode != this.popup.container
             && el != this.tooltipNode && e.relatedTarget != this.tooltipNode
             && e.relatedTarget != text
         ) {


### PR DESCRIPTION
Fix typeerror "Cannot read property 'container' of undefined" when using live autocomplete. Error can occur when editor loses focus and the autocomplete popup has never been shown.
